### PR TITLE
Add hover tooltip on Actions tab button for dnd 3.0.x sheets

### DIFF
--- a/src/module/foundryvtt-dnd5eCharacterActions.js
+++ b/src/module/foundryvtt-dnd5eCharacterActions.js
@@ -34,7 +34,9 @@ async function addActionsTab(app, html, data) {
   if ($(html).closest('.sheet').is('.dnd5e2')) {
     // New 5e 3.0 Character sheets
     // Update the nav menu
-    const actionsTabButton = $('<a class="item" data-tab="actions"> \n <i class="fas fa-fist-raised"></i> \n </a>');
+    const actionsTabButton = $(
+      '<a class="item control" data-group="primary" data-tab="actions" data-tooltip="DND5E.ActionPl" aria-label="DND5E.ActionPl"> \n <i class="fas fa-fist-raised"></i> \n </a>'
+    );
     const tabs = html.find('.tabs[data-group="primary"]');
     tabs.prepend(actionsTabButton);
 


### PR DESCRIPTION
To fit with the new D&D 3.0.0 sheets, this PR adds the missing tooltip when hovering the button on the side of the character sheet.

<img width="233" alt="Screenshot 2024-03-26 at 19 00 39" src="https://github.com/eastcw/foundryvtt-dnd5eCharacterActions/assets/1363056/365de7a0-4bea-4414-9698-bf7609267ddc">
