### PR TITLE
Migrate flattenObject to foundry.utils.flattenObject

### DIFF
--- a/src/module/foundryvtt-dnd5eCharacterActions.js
+++ b/src/module/foundryvtt-dnd5eCharacterActions.js
@@ -97,7 +97,7 @@ Hooks.once('init', async function () {
   registerSettings();
 
   // Preload Handlebars templates
-  await loadTemplates(Object.values(flattenObject(TEMPLATES)));
+  await loadTemplates(Object.values(foundry.utils.flattenObject(TEMPLATES)));
   const characterActionsModuleData = getGame().modules.get(MODULE_ID);
   if (characterActionsModuleData) {
     characterActionsModuleData.api = {


### PR DESCRIPTION
Just to cleanup deprecated methods v12 warnings :)

I do realise now that I've pushed this, there might a condition required to support v11 if the method is not preset in `foundry.utils` at that time? 🤔 